### PR TITLE
add verified 11 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,7 +5,8 @@
   "version": "2.0.0",
   "authors": [{ "name": "Mark Pearce", "discord": "Mark Pearce#2772" }],
   "compatibility": {
-    "minimum": 10
+    "minimum": 10,
+    "verified": 11
   },
   "packs": [
     {


### PR DESCRIPTION
i don't see any issues in the console log related to these maps in v11.  adding verified 11 will make it not flagged as possibly broken for v11 users.